### PR TITLE
[TASK] Move 'indexed_search' from dependency to suggestion

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -15,11 +15,12 @@ $EM_CONF[$_EXTKEY] = [
         'depends' => [
             'typo3' => '8.7.0-8.7.99',
             'backend' => '8.7.0-8.7.99',
-            'indexed_search' => '8.7.0-8.7.99',
         ],
         'conflicts' => [
             'compatibility6' => '0.0.0',
         ],
-        'suggests' => [],
+        'suggests' => [
+            'indexed_search' => '8.7.0-8.7.99',
+        ],
     ],
 ];


### PR DESCRIPTION
If 'indexed_search' is a dependency it throws an exception in the upgrade wizard, if you don't have 'indexed_search' installed