### PR TITLE
[BUGFIX] Correctly handle non-existing level in menu.directory VH

### DIFF
--- a/Classes/ViewHelpers/Menu/DirectoryViewHelper.php
+++ b/Classes/ViewHelpers/Menu/DirectoryViewHelper.php
@@ -75,6 +75,9 @@ class DirectoryViewHelper extends AbstractMenuViewHelper
         $includeMenuSeparator = (bool)$this->arguments['includeMenuSeparator'];
 
         $pageUids = $this->getPageUids($pageUids, $entryLevel);
+        if (empty($pageUids)) {
+            return '';
+        }
         $pages = $typoScriptFrontendController->sys_page->getMenu(
             $pageUids,
             '*',

--- a/Classes/ViewHelpers/Menu/ListViewHelper.php
+++ b/Classes/ViewHelpers/Menu/ListViewHelper.php
@@ -73,6 +73,9 @@ class ListViewHelper extends AbstractMenuViewHelper
         $includeMenuSeparator = (bool)$this->arguments['includeMenuSeparator'];
 
         $pageUids = $this->getPageUids($pageUids, $entryLevel);
+        if (empty($pageUids)) {
+            return '';
+        }
         $pages = $typoScriptFrontendController->sys_page->getMenuForPages(
             $pageUids,
             '*',

--- a/Classes/ViewHelpers/Menu/MenuViewHelperTrait.php
+++ b/Classes/ViewHelpers/Menu/MenuViewHelperTrait.php
@@ -78,18 +78,21 @@ trait MenuViewHelperTrait
         $pageUids = array_filter($pageUids);
 
         // If no pages have been defined, use the current page
-        if (empty($pageUids)) {
-            if ($entryLevel !== null) {
-                if ($entryLevel < 0) {
-                    $entryLevel = count($typoScriptFrontendController->tmpl->rootLine) - 1 + $entryLevel;
-                }
-                $pageUids = [$typoScriptFrontendController->tmpl->rootLine[$entryLevel]['uid']];
-            } else {
-                $pageUids = [$typoScriptFrontendController->id];
-            }
+        if (!empty($pageUids)) {
+            return $pageUids;
         }
 
-        return $pageUids;
+        if ($entryLevel === null) {
+            return [$typoScriptFrontendController->id];
+        }
+
+        if ($entryLevel < 0) {
+            $entryLevel = count($typoScriptFrontendController->tmpl->rootLine) - 1 + $entryLevel;
+        }
+        if (isset($typoScriptFrontendController->tmpl->rootLine[$entryLevel]['uid'])) {
+            return [$typoScriptFrontendController->tmpl->rootLine[$entryLevel]['uid']];
+        }
+        return [];
     }
 
     /**


### PR DESCRIPTION
Providing a non-existing entry-level to the getPageUids() method
now returns an empty array instead of an array with key zero and
a null value.

This way we can correctly stop processing in the viewhelpers
using the MenuViewHelperTrait.

Resolves: #4